### PR TITLE
Add route/upstream tracking

### DIFF
--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/entity/ApiBinding.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/entity/ApiBinding.java
@@ -16,6 +16,12 @@ public class ApiBinding {
     private String userName;
     private String personaType;
 
+    @Column(name = "route_id")
+    private String routeId;
+
+    @Column(name = "upstream_id")
+    private String upstreamId;
+
     @Column(columnDefinition = "TEXT")
     private String boundVars;
 

--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteService.java
@@ -159,6 +159,8 @@ public class RouteService {
 
             record.setUserName(userName);
             record.setPersonaType(personaType);
+            record.setRouteId(routeId);
+            record.setUpstreamId(upstreamIdFromTpl);
             record.setApiId(api.getId());
             record.setBoundAt(LocalDateTime.now());
             try {

--- a/etcd-based/data/init-data-ddl.sql
+++ b/etcd-based/data/init-data-ddl.sql
@@ -41,6 +41,8 @@ CREATE TABLE IF NOT EXISTS api_bindings (
     user_name VARCHAR(64) NOT NULL,              -- 使用者帳號
     persona_type VARCHAR(64) NOT NULL,           -- 如 tenant, provider
     api_id INT NOT NULL,                         -- 對應 api_definitions.id
+    route_id VARCHAR(255) NOT NULL,              -- 生成的 APISIX route id
+    upstream_id VARCHAR(255) NOT NULL,           -- 生成的 APISIX upstream id
     bound_vars JSON NOT NULL,                    -- 渲染後的 vars 結構
     template_context JSON NOT NULL,              -- 渲染用變數，如 userName、uri、upstream_id 等
     bound_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add `route_id` and `upstream_id` columns to `api_bindings`
- persist the route and upstream IDs when binding APIs
- expose fields on `ApiBinding` entity

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444e9ef778832d8d2b80fc0792e723