### PR TITLE
Implement hashed upstream ID

### DIFF
--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteService.java
@@ -68,10 +68,16 @@ public class RouteService {
                 throw new RuntimeException("Failed to parse rendered upstream_template JSON", e);
             }
 
-            String upstreamIdFromTpl = (String) desiredUpstream.get("id");
-            if (upstreamIdFromTpl == null) {
-                throw new RuntimeException("Missing upstream id in rendered template.");
+            // Generate unique upstream id based on the upstream content
+            String upstreamHash;
+            try {
+                upstreamHash = TemplateUtil.shortHash(mapper.writeValueAsString(desiredUpstream));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to hash upstream", e);
             }
+            String upstreamIdFromTpl = "u-" + upstreamHash;
+            desiredUpstream.put("id", upstreamIdFromTpl);
+            context.put("upstream_id", upstreamIdFromTpl);
 
             String upstreamCheckUrl = "http://localhost:9180/apisix/admin/upstreams/" + upstreamIdFromTpl;
             HttpHeaders headers = new HttpHeaders();

--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/utils/TemplateUtil.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/utils/TemplateUtil.java
@@ -5,6 +5,9 @@ import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 public class TemplateUtil {
@@ -25,6 +28,23 @@ public class TemplateUtil {
             throw (e instanceof java.io.IOException)
                     ? new UncheckedIOException((java.io.IOException) e)
                     : new RuntimeException("Template rendering failed", e);
+        }
+    }
+
+    /**
+     * Generate an 8-character hash based on the given input string using SHA-256.
+     */
+    public static String shortHash(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 4; i++) { // first 4 bytes -> 8 hex chars
+                sb.append(String.format("%02x", digest[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to compute hash", e);
         }
     }
 }

--- a/etcd-based/data/insert-data.sql
+++ b/etcd-based/data/insert-data.sql
@@ -36,7 +36,7 @@ INSERT INTO route_templates (
         "persona_type": "{{personaType}}",
         "user": "{{userName}}",
         "url": "{{url}}",
-        "upstream_id": "{{userName}}-openai-upstream"
+        "upstream_id": "{{upstream_id}}"
     }
  }',
  '{
@@ -114,7 +114,7 @@ INSERT INTO upstream_templates (code, description, upstream_template) VALUES
 ('openai-upstream',
  'OpenAI 專用 Upstream，帶有使用者動態 ID',
  '{
-    "id": "{{userName}}-openai-upstream",
+    "id": "{{upstream_id}}",
     "type": "roundrobin",
     "scheme": "http",
     "pass_host": "rewrite",


### PR DESCRIPTION
## Summary
- add `shortHash` util to generate consistent 8-char hash IDs
- compute upstream id from hashed upstream content in `RouteService`
- update SQL templates to use the new generated id

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444dfc54f4832db4e305a61ee27b96