### PR TITLE
Refactor insert templates and route service

### DIFF
--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/utils/TemplateValidator.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/utils/TemplateValidator.java
@@ -102,10 +102,10 @@ public class TemplateValidator {
     }
 
     /**
-     * 根據 upstream template 是否包含 {{ node.xxx }} 來決定是否驗證 nodes 結構
+     * 根據 upstream template 是否需要 nodes 參數來決定是否驗證 nodes 結構
      */
     public static void validateIfNodeTemplateUsed(String upstreamTemplate, Map<String, Object> context) {
-        if (upstreamTemplate.contains("{{ node.")) {
+        if (upstreamTemplate.contains("{{ node.") || upstreamTemplate.contains("{{nodes_json}}")) {
             validateNodesStructure(context);
         }
     }

--- a/etcd-based/data/insert-data.sql
+++ b/etcd-based/data/insert-data.sql
@@ -58,17 +58,7 @@ INSERT INTO route_templates (
     "custom-auth": {
         "persona_type": "{{personaType}}",
         "user": "{{userName}}"
-    }
-    {% if count and time_window %},
-    "limit-count": {
-        "count": {{count}},
-        "time_window": {{time_window}},
-        "key": "remote_addr",
-        "policy": "local"
-    }
-    {% elseif count or time_window %},
-    "__template_warning__": "limit-count plugin requires both count and time_window to be set."
-    {% endif %}
+    }{{limit_count_plugin}}
  }',
  '{
     "provider": [
@@ -130,16 +120,8 @@ INSERT INTO upstream_templates (code, description, upstream_template) VALUES
         "requests": 1000000,
         "size": 5000
     },
-    "nodes": [
-        {% for node in nodes %}
-        {
-            "host": "{{node.host}}",
-            "port": {{node.port}},
-            "weight": {{node.weight}}
-        }{% if not loop.last %},{% endif %}
-        {% endfor %}
-    ]
- }');
+    "nodes": {{nodes_json}}
+}');
 
 -- 插入 api_definitions（保持不變）
 INSERT INTO api_definitions (


### PR DESCRIPTION
## Summary
- simplify SQL templates by removing control structures
- build plugin and node JSON in `RouteService`
- validate nodes when `{{nodes_json}}` appears in template

## Testing
- `mvn -q -f etcd-based/apisix_service/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444fe1f538832d9dc0ce174341b922