### PR TITLE
Make APISIX admin configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+APISIX_ADMIN_URL=http://localhost:9180/apisix/admin
+APISIX_ADMIN_API_KEY=admin123

--- a/etcd-based/apisix_service/README.md
+++ b/etcd-based/apisix_service/README.md
@@ -19,3 +19,10 @@ A minimal Spring Boot service that dynamically subscribes user, API, and persona
 - **Jackson** (for JSON processing)
 - **Lombok**
 - **Maven**
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the following variables if needed:
+
+- `APISIX_ADMIN_URL` – base URL of the APISIX Admin API.
+- `APISIX_ADMIN_API_KEY` – API key for accessing the Admin API.

--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteManager.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/service/RouteManager.java
@@ -10,18 +10,25 @@ import java.util.Map;
 
 @Component
 public class RouteManager {
+    private static final String DEFAULT_ADMIN_URL = "http://localhost:9180/apisix/admin";
+    private static final String DEFAULT_ADMIN_KEY = "admin123";
+
     private final RestTemplate restTemplate;
     private final ObjectMapper mapper;
+    private final String adminUrl;
+    private final String adminKey;
 
     public RouteManager(RestTemplate restTemplate, ObjectMapper mapper) {
         this.restTemplate = restTemplate;
         this.mapper = mapper;
+        this.adminUrl = System.getenv().getOrDefault("APISIX_ADMIN_URL", DEFAULT_ADMIN_URL);
+        this.adminKey = System.getenv().getOrDefault("APISIX_ADMIN_API_KEY", DEFAULT_ADMIN_KEY);
     }
 
     public void createOrUpdateRoute(String routeId, Map<String, Object> route) {
-        String url = "http://localhost:9180/apisix/admin/routes/" + routeId;
+        String url = adminUrl + "/routes/" + routeId;
         HttpHeaders headers = new HttpHeaders();
-        headers.set("X-API-KEY", "admin123");
+        headers.set("X-API-KEY", adminKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
         try {
             HttpEntity<String> entity = new HttpEntity<>(mapper.writeValueAsString(route), headers);

--- a/etcd-based/apisix_service/src/main/java/com/example/apisix/service/UpstreamManager.java
+++ b/etcd-based/apisix_service/src/main/java/com/example/apisix/service/UpstreamManager.java
@@ -13,19 +13,26 @@ import java.util.Objects;
 
 @Component
 public class UpstreamManager {
+    private static final String DEFAULT_ADMIN_URL = "http://localhost:9180/apisix/admin";
+    private static final String DEFAULT_ADMIN_KEY = "admin123";
+
     private final RestTemplate restTemplate;
     private final ObjectMapper mapper;
+    private final String adminUrl;
+    private final String adminKey;
 
     public UpstreamManager(RestTemplate restTemplate, ObjectMapper mapper) {
         this.restTemplate = restTemplate;
         this.mapper = mapper;
+        this.adminUrl = System.getenv().getOrDefault("APISIX_ADMIN_URL", DEFAULT_ADMIN_URL);
+        this.adminKey = System.getenv().getOrDefault("APISIX_ADMIN_API_KEY", DEFAULT_ADMIN_KEY);
     }
 
     public void ensureUpstream(Map<String, Object> desiredUpstream) {
         String upstreamId = (String) desiredUpstream.get("id");
-        String url = "http://localhost:9180/apisix/admin/upstreams/" + upstreamId;
+        String url = adminUrl + "/upstreams/" + upstreamId;
         HttpHeaders headers = new HttpHeaders();
-        headers.set("X-API-KEY", "admin123");
+        headers.set("X-API-KEY", adminKey);
 
         boolean needsCreate = true;
         try {

--- a/etcd-based/commands
+++ b/etcd-based/commands
@@ -1,6 +1,11 @@
-# export all settings
+#!/bin/bash
+# export all settings using APISIX Admin API
+
+APISIX_ADMIN_URL=${APISIX_ADMIN_URL:-http://localhost:9180/apisix/admin}
+APISIX_ADMIN_API_KEY=${APISIX_ADMIN_API_KEY:-admin123}
+
 for item in routes services upstreams consumers ssl global_rules; do
-  curl -s http://localhost:9180/apisix/admin/$item -H "X-API-KEY: admin123" > ./raw_settings/${item}.json
+  curl -s "$APISIX_ADMIN_URL/$item" -H "X-API-KEY: $APISIX_ADMIN_API_KEY" > ./raw_settings/${item}.json
 done
 
 #when etcd_data cannot be loaded


### PR DESCRIPTION
## Summary
- add `.env.example` with APISIX admin variables
- load `APISIX_ADMIN_URL` and `APISIX_ADMIN_API_KEY` in `UpstreamManager`
- load same variables in `RouteManager`
- make `commands` script read env vars
- document environment vars in README

## Testing
- `python3 -m py_compile template-based/generate.py`

------
https://chatgpt.com/codex/tasks/task_e_6844569f524c832db78ef730eb26bdf6