### PR TITLE
Update README for permission fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,39 @@ It includes custom plugins, a Spring Boot service for dynamic route subscription
 
 ## Usage
 
-1. **Start the stack**
+1. **Prepare configuration and environment variables**
+   If `docker-compose up` fails with `permission denied` errors, adjust the
+   permissions of the configuration folders so the containers can read them:
+   ```bash
+   sudo chmod -R 755 config plugins sql scripts
+   sudo chmod +x scripts/export-settings.sh
+   ```
+
+   Copy `.env.example` to `.env` and verify the contents:
+   ```bash
+   cp .env.example .env
+   cat .env
+   ```
+   A valid `.env` file looks like this:
+   ```dotenv
+   APISIX_ADMIN_URL=http://localhost:9180/apisix/admin
+   APISIX_ADMIN_API_KEY=admin123
+   ```
+
+2. **Start the stack**
    ```bash
    docker-compose up -d
    ```
    This launches APISIX, etcd, MariaDB and the dashboard.
 
-2. **Run the Spring Boot service**
+3. **Run the Spring Boot service**
    ```bash
    cd service
    mvn spring-boot:run
    ```
    The service exposes APIs for subscribing routes which are pushed to APISIX via the Admin API.
 
-3. **Export current APISIX settings**
+4. **Export current APISIX settings**
    ```bash
    bash scripts/export-settings.sh
    ```


### PR DESCRIPTION
## Summary
- add instructions to fix permissions when running `docker-compose`
- document how to create `.env` from example

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445c11c6f4832d87f48dc9d66e03b5