### PR TITLE
Fix setup steps and add default env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+APISIX_ADMIN_URL=http://localhost:9180/apisix/admin
+APISIX_ADMIN_API_KEY=admin123

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ It includes custom plugins, a Spring Boot service for dynamic route subscription
    sudo chmod +x scripts/export-settings.sh
    ```
 
+   Create the `etcd_data` directory for the etcd container:
+   ```bash
+   mkdir -p etcd_data
+   chmod 755 etcd_data
+   ```
+
    Copy `.env.example` to `.env` and verify the contents:
    ```bash
    cp .env.example .env


### PR DESCRIPTION
## Summary
- add `.env` with APISIX admin defaults
- document creating `etcd_data` dir so compose starts

## Testing
- `mvn -q -DskipTests validate` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68445ecea6e4832d9a303c57ef2c34d7