### PR TITLE
Fix upstream template validation

### DIFF
--- a/service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/service/src/main/java/com/example/apisix/service/RouteService.java
@@ -80,13 +80,15 @@ public class RouteService {
 
             context.put("limit_count_plugin", limitCountPlugin);
 
-            Map<String, String> allTemplates = Map.of(
+            Map<String, String> basicTemplates = Map.of(
                 "route_template", tpl.getRouteTemplate(),
                 "plugin_template", tpl.getPluginTemplate(),
-                "vars_template", tpl.getVarsTemplate(),
-                "upstream_template", upstreamTpl.getUpstreamTemplate()
+                "vars_template", tpl.getVarsTemplate()
             );
-            TemplateValidator.validateAllTemplates(allTemplates, context);
+            TemplateValidator.validateAllTemplates(basicTemplates, context);
+            TemplateValidator.validateTemplateVariables(
+                    upstreamTpl.getUpstreamTemplate(), context,
+                    "upstream_template", Set.of("upstream_id"));
             TemplateValidator.validateIfNodeTemplateUsed(upstreamTpl.getUpstreamTemplate(), context);
 
             Map<String, Object> desiredUpstream = templateRenderer.renderUpstream(upstreamTpl.getUpstreamTemplate(), context);

--- a/service/src/main/java/com/example/apisix/utils/TemplateValidator.java
+++ b/service/src/main/java/com/example/apisix/utils/TemplateValidator.java
@@ -53,11 +53,24 @@ public class TemplateValidator {
     /**
      * 驗證模板中所有必填變數是否有出現在 context 中
      */
-    public static void validateTemplateVariables(String template, Map<String, Object> context, String templateName) {
+    public static void validateTemplateVariables(String template,
+                                                 Map<String, Object> context,
+                                                 String templateName) {
+        validateTemplateVariables(template, context, templateName, Collections.emptySet());
+    }
+
+    /**
+     * 驗證模板中所有必填變數是否有出現在 context 中，允許忽略部分變數
+     */
+    public static void validateTemplateVariables(String template,
+                                                 Map<String, Object> context,
+                                                 String templateName,
+                                                 Set<String> ignoreVars) {
         Set<String> allVars = extractAllVariables(template);
         Set<String> optionalVars = extractOptionalVariables(template);
         Set<String> requiredVars = new HashSet<>(allVars);
         requiredVars.removeAll(optionalVars);
+        requiredVars.removeAll(ignoreVars);
 
         Set<String> missing = requiredVars.stream()
                 .filter(key -> !context.containsKey(key))


### PR DESCRIPTION
## Summary
- allow ignoring variables during template validation
- skip validating `upstream_id` for upstream templates

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844672595b0832d9b2dca315e2cd60c