### PR TITLE
Use hashed IDs for routes and upstreams

### DIFF
--- a/service/src/main/java/com/example/apisix/utils/IdUtil.java
+++ b/service/src/main/java/com/example/apisix/utils/IdUtil.java
@@ -1,0 +1,20 @@
+package com.example.apisix.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.apisix.utils.TemplateUtil;
+
+public class IdUtil {
+    /**
+     * Generate an ID with the given prefix based on the short hash of the provided object.
+     * The object will be serialized to JSON using the supplied ObjectMapper.
+     */
+    public static String generateId(String prefix, Object obj, ObjectMapper mapper) {
+        try {
+            String json = (obj instanceof String) ? (String) obj : mapper.writeValueAsString(obj);
+            return prefix + TemplateUtil.shortHash(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to generate id", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `IdUtil` to centralize ID generation using short hashes
- generate route ID with `r-` prefix and hashed route content
- use `IdUtil` for upstream ID generation

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684468720afc832da1006d4b3bb48fc8