### PR TITLE
Fix missing upstream on auth-limit route

### DIFF
--- a/service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/service/src/main/java/com/example/apisix/service/RouteService.java
@@ -101,12 +101,15 @@ public class RouteService {
     }
 
     private void validateTemplates(RouteTemplate tpl, UpstreamTemplate upstreamTpl, Map<String, Object> context) {
-        Map<String, String> basicTemplates = Map.of(
-            "route_template", tpl.getRouteTemplate(),
-            "plugin_template", tpl.getPluginTemplate(),
-            "vars_template", tpl.getVarsTemplate()
-        );
-        TemplateValidator.validateAllTemplates(basicTemplates, context);
+        TemplateValidator.validateTemplateVariables(
+                tpl.getRouteTemplate(), context,
+                "route_template", Set.of("upstream_id"));
+        TemplateValidator.validateTemplateVariables(
+                tpl.getPluginTemplate(), context,
+                "plugin_template");
+        TemplateValidator.validateTemplateVariables(
+                tpl.getVarsTemplate(), context,
+                "vars_template");
         TemplateValidator.validateTemplateVariables(
                 upstreamTpl.getUpstreamTemplate(), context,
                 "upstream_template", Set.of("upstream_id"));

--- a/sql/insert-data.sql
+++ b/sql/insert-data.sql
@@ -53,7 +53,7 @@ INSERT INTO route_templates (
 -- auth-limit（count 與 time_window 必須同時存在）
 ('auth-limit',
  'auth with optional rate limit（count 與 time_window 必須成對出現）',
- '{"uri": "{{uri}}", "name": "{{userName}}-{{name}}", "methods": ["GET"]}',
+ '{"uri": "{{uri}}", "name": "{{userName}}-{{name}}", "methods": ["GET"], "upstream_id": "{{upstream_id}}"}',
  '{
     "custom-auth": {
         "persona_type": "{{personaType}}",


### PR DESCRIPTION
## Summary
- include `upstream_id` variable in `auth-limit` route template
- avoid validating `upstream_id` in `route_template`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446e1eade0832d91d89efacfc61806