### PR TITLE
Fix missing upstream name

### DIFF
--- a/sql/insert-data.sql
+++ b/sql/insert-data.sql
@@ -152,6 +152,7 @@ INSERT INTO upstream_templates (code, description, upstream_template) VALUES
  'OpenAI 專用 Upstream，帶有使用者動態 ID',
  '{
     "id": "{{upstream_id}}",
+    "name": "{{userName}}-{{name}}-upstream",
     "type": "roundrobin",
     "scheme": "http",
     "pass_host": "rewrite",


### PR DESCRIPTION
## Summary
- include a `name` field in the `openai-upstream` template so generated upstreams retain their name

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844707bb1dc832dba41c04e97181150