### PR TITLE
Add extra curl test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ It includes custom plugins, a Spring Boot service for dynamic route subscription
    ```
    The script saves the output JSON files under `config/raw/`.
 
+5. **Run the curl test script**
+   ```bash
+   bash scripts/test-subscribe.sh
+   ```
+   The script issues sample subscription requests demonstrating success and
+   failure cases, including rate limiting and multi-upstream routing.
+
 ## What can this project do?
 
 - Demonstrates how to configure and extend APISIX with custom plugins.

--- a/scripts/test-subscribe.sh
+++ b/scripts/test-subscribe.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Simple test script for the APISIX Route Subscription Service.
+# Uses curl to hit the service with various payloads.
+# SERVICE_URL can be overridden via environment variable.
+
+SERVICE_URL=${SERVICE_URL:-http://localhost:8080}
+
+print_header() {
+  echo -e "\n---- $1 ----"
+}
+
+# 1. Valid subscription
+print_header "Valid subscription (persona-basic)"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "alice",
+      "personaType": "tenant",
+      "apiKey": "alice-key",
+      "apis": ["getUserInfo"],
+      "extraParams": {}
+    }'
+echo
+
+# 2. Unknown API should fail
+print_header "Unknown API"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "alice",
+      "personaType": "tenant",
+      "apiKey": "alice-key",
+      "apis": ["doesNotExist"]
+    }'
+echo
+
+# 3. Missing required field
+print_header "Missing personaType"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "bob",
+      "apiKey": "bob-key",
+      "apis": ["getUserInfo"]
+    }'
+echo
+
+# 4. Invalid limit-count parameters
+print_header "Invalid limit-count parameters"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "carol",
+      "personaType": "provider",
+      "apiKey": "carol-key",
+      "apis": ["limitCountTest"],
+      "extraParams": { "count": 10 }
+    }'
+echo
+
+# 5. Valid limit-count parameters
+print_header "Valid limit-count parameters"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "carol",
+      "personaType": "provider",
+      "apiKey": "carol-key",
+      "apis": ["limitCountTest"],
+      "extraParams": { "count": 10, "time_window": 60 }
+    }'
+echo
+
+# 6. Multiple upstream router
+print_header "Multiple upstream router"
+curl -i -X POST "$SERVICE_URL/apisix/subscribe" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "userName": "dave",
+      "personaType": "tenant",
+      "apiKey": "dave-key",
+      "apis": ["modelInference"]
+    }'
+echo


### PR DESCRIPTION
## Summary
- improve README description of test script
- extend `test-subscribe.sh` with valid rate limiting and multi-upstream tests

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844721c1538832db32424bf5d6794e3