### PR TITLE
Improve curl test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ It includes custom plugins, a Spring Boot service for dynamic route subscription
    ```
    The script saves the output JSON files under `config/raw/`.
 
+5. **Run the curl test script**
+   The test script sends example subscription requests to the service. If the
+   service is not running on `localhost:8080`, override `SERVICE_URL`:
+   ```bash
+   SERVICE_URL=http://localhost:8080 bash scripts/test-subscribe.sh
+   ```
+   Each case prints the response and HTTP status code so you can verify success
+   or failure.  Examples cover rate limiting and multi-upstream routing.
+
 ## What can this project do?
 
 - Demonstrates how to configure and extend APISIX with custom plugins.

--- a/scripts/test-subscribe.sh
+++ b/scripts/test-subscribe.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Test various subscription requests against the APISIX Route Subscription Service.
+# The service is expected to run on localhost:8080 by default.
+# Override SERVICE_URL to point to a different base URL.
+
+SERVICE_URL=${SERVICE_URL:-http://localhost:8080}
+
+print_case() {
+  local title=$1
+  local data=$2
+
+  echo -e "\n---- $title ----"
+  # -s suppress progress, -D - prints headers to stdout
+  curl -s -D - -o /tmp/resp.$$ -H "Content-Type: application/json" \
+       -d "$data" "$SERVICE_URL/apisix/subscribe"
+  local status=$(grep -m1 HTTP /tmp/resp.$$ | awk '{print $2}')
+  cat /tmp/resp.$$
+  echo "HTTP_STATUS:$status"
+  rm /tmp/resp.$$
+}
+
+print_case "Valid subscription (persona-basic)" '{
+  "userName": "alice",
+  "personaType": "tenant",
+  "apiKey": "alice-key",
+  "apis": ["getUserInfo"],
+  "extraParams": {}
+}'
+
+print_case "Unknown API" '{
+  "userName": "alice",
+  "personaType": "tenant",
+  "apiKey": "alice-key",
+  "apis": ["doesNotExist"]
+}'
+
+print_case "Missing personaType" '{
+  "userName": "bob",
+  "apiKey": "bob-key",
+  "apis": ["getUserInfo"]
+}'
+
+print_case "Invalid limit-count parameters" '{
+  "userName": "carol",
+  "personaType": "provider",
+  "apiKey": "carol-key",
+  "apis": ["limitCountTest"],
+  "extraParams": { "count": 10 }
+}'
+
+print_case "Valid limit-count parameters" '{
+  "userName": "carol",
+  "personaType": "provider",
+  "apiKey": "carol-key",
+  "apis": ["limitCountTest"],
+  "extraParams": { "count": 10, "time_window": 60 }
+}'
+
+print_case "Multiple upstream router" '{
+  "userName": "dave",
+  "personaType": "tenant",
+  "apiKey": "dave-key",
+  "apis": ["modelInference"]
+}'


### PR DESCRIPTION
## Summary
- expand README instructions for running the test script
- rework `test-subscribe.sh` to print HTTP status for each test case

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844721c1538832db32424bf5d6794e3