### PR TITLE
Support dynamic multiple upstream rules

### DIFF
--- a/sql/insert-data.sql
+++ b/sql/insert-data.sql
@@ -80,28 +80,7 @@ INSERT INTO route_templates (
  '{"uri": "/inference", "methods": ["POST"], "name": "{{userName}}-model-route", "upstream_id": "dummy-upstream"}',
  '{
     "multiple-upstream-plugin": {
-      "rules": [
-        {
-          "name": "GPT-4o",
-          "match": [
-            ["http_model", "contains", "gpt-4o"]
-          ],
-          "upstream_id": "upstream-gpt4o",
-          "inject_headers": {
-            "x-api-key": "gpt4o-key-abc"
-          }
-        },
-        {
-          "name": "GPT-3.5",
-          "match": [
-            ["http_model", "contains", "gpt3.5"]
-          ],
-          "upstream_id": "upstream-gpt35",
-          "inject_headers": {
-            "x-api-key": "gpt35-key-xyz"
-          }
-        }
-      ]
+      "rules": []
     }
  }',
  '{


### PR DESCRIPTION
## Summary
- enable dynamic rule generation for `multiple-upstream-plugin`
- create new upstreams from API's upstream template when `multi_upstreams` array is provided
- simplified template for `model-upstream-router` to be populated at runtime

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447917b450832d95b489c181112b7e