### PR TITLE
Fix upstream handling in subscription service

### DIFF
--- a/scripts/test-subscribe.sh
+++ b/scripts/test-subscribe.sh
@@ -54,7 +54,14 @@ print_case "Valid limit-count parameters" '{
   "personaType": "provider",
   "apiKey": "carol-key",
   "apis": ["limitCountTest"],
-  "extraParams": { "count": 10, "time_window": 60 }
+  "extraParams": {
+    "count": 10,
+    "time_window": 60,
+    "upstream_host": "openai.example.com",
+    "nodes": [
+      { "host": "openai.example.com", "port": 80, "weight": 1 }
+    ]
+  }
 }'
 
 print_case "Multiple upstream router" '{

--- a/service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/service/src/main/java/com/example/apisix/service/RouteService.java
@@ -117,10 +117,18 @@ public class RouteService {
     }
 
     private String createUpstream(UpstreamTemplate upstreamTpl, Map<String, Object> context) {
-        Map<String, Object> desiredUpstream = templateRenderer.renderUpstream(upstreamTpl.getUpstreamTemplate(), context);
-        String upstreamIdFromTpl = IdUtil.generateId("u-", desiredUpstream, mapper);
+        Map<String, Object> desiredUpstream =
+            templateRenderer.renderUpstream(upstreamTpl.getUpstreamTemplate(), context);
+
+        Object idObj = desiredUpstream.get("id");
+        String upstreamIdFromTpl =
+            (idObj instanceof String && !((String) idObj).isBlank())
+                ? (String) idObj
+                : IdUtil.generateId("u-", desiredUpstream, mapper);
+
         desiredUpstream.put("id", upstreamIdFromTpl);
         context.put("upstream_id", upstreamIdFromTpl);
+
         upstreamManager.ensureUpstream(desiredUpstream);
         return upstreamIdFromTpl;
     }


### PR DESCRIPTION
## Summary
- preserve upstream ID from template when present
- expand test-subscribe script with required params for rate limit case

## Testing
- `bash -n scripts/test-subscribe.sh`

------
https://chatgpt.com/codex/tasks/task_e_68447b00ad74832d8b92f096ebd6077d