### PR TITLE
Add script for resetting compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ It includes custom plugins, a Spring Boot service for dynamic route subscription
    Each case prints the response and HTTP status code so you can verify success
    or failure.  Examples cover rate limiting and multi-upstream routing.
 
+6. **Reset the environment**
+   When you need a clean etcd and database state, run:
+   ```bash
+   bash scripts/reset-compose.sh
+   ```
+   The script removes the existing volumes and `etcd_data` directory then
+   starts the stack again.
+
 ## What can this project do?
 
 - Demonstrates how to configure and extend APISIX with custom plugins.

--- a/scripts/reset-compose.sh
+++ b/scripts/reset-compose.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Reset etcd and MariaDB data and restart docker-compose stack
+
+set -euo pipefail
+
+# Stop containers and remove volumes
+# -v ensures anonymous and named volumes are removed (MariaDB data)
+docker-compose down -v
+
+# Clear etcd data (host directory mounted into etcd container)
+rm -rf ./etcd_data
+mkdir -p ./etcd_data
+chmod 755 ./etcd_data
+
+# Start stack again
+docker-compose up -d


### PR DESCRIPTION
## Summary
- add `scripts/reset-compose.sh` to remove etcd and MariaDB data and restart the stack
- document the new command in the usage section

## Testing
- `bash -n scripts/reset-compose.sh`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447c8c6578832d868c5dbccf21987d