### PR TITLE
Allow missing base upstream nodes for multi upstreams

### DIFF
--- a/service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/service/src/main/java/com/example/apisix/service/RouteService.java
@@ -141,7 +141,7 @@ public class RouteService {
                 itemCtx.putAll((Map<String, Object>) obj);
                 TemplateValidator.validateTemplateVariables(
                         upstreamTpl.getUpstreamTemplate(), itemCtx,
-                        "upstream_template", Set.of("upstream_id"));
+                        "upstream_template", Set.of("upstream_id", "nodes_json"));
                 TemplateValidator.validateIfNodeTemplateUsed(upstreamTpl.getUpstreamTemplate(), itemCtx);
             }
         }


### PR DESCRIPTION
## Summary
- relax validation for multi_upstreams to not require `nodes_json`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448eb87dfc832db4ee95ad0ea4fc42