### PR TITLE
Update multi-upstream plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ requested API names and optional `extraParams`. For each API the service:
 
 `extraParams.multi_upstreams` allows defining additional upstreams and routing
 rules for the `multiple-upstream-plugin`. Each item may specify a `match` value
-for the `http_model` header, an optional `api_key` header to inject and custom
+for the `http_x_model` header, an optional `api-key` header to inject and custom
 upstream settings.
 
 ### Notes

--- a/plugins/multiple-upstream-plugin.lua
+++ b/plugins/multiple-upstream-plugin.lua
@@ -3,12 +3,39 @@ local core = require("apisix.core")
 local rule_schema = {
     type = "object",
     properties = {
-        name = { type = "string" },
-        match = { type = "array" },
+        match = {
+            type = "object",
+            properties = {
+                vars = {
+                    type = "array",
+                    items = {
+                        type = "object",
+                        properties = {
+                            var_name = { type = "string" },
+                            operator = { type = "string" },
+                            value = { type = "string" }
+                        },
+                        required = {"var_name", "operator", "value"}
+                    }
+                }
+            },
+            required = {"vars"}
+        },
+        url = { type = "string" },
         upstream_id = { type = "string" },
-        inject_headers = { type = "object" }
+        headers = {
+            type = "array",
+            items = {
+                type = "object",
+                properties = {
+                    key = { type = "string" },
+                    value = { type = "string" }
+                },
+                required = {"key", "value"}
+            }
+        }
     },
-    required = {"name", "match", "upstream_id"}
+    required = {"match", "upstream_id"}
 }
 
 local schema = {
@@ -29,11 +56,13 @@ local _M = {
 }
 
 local function match_rule(rule, ctx)
-    if not rule.match then
+    if not rule.match or not rule.match.vars then
         return false
     end
-    for _, cond in ipairs(rule.match) do
-        local var_name, op, val = cond[1], cond[2], cond[3]
+    for _, cond in ipairs(rule.match.vars) do
+        local var_name = cond.var_name
+        local op = cond.operator
+        local val = cond.value
         local v = ctx.var[var_name]
         if op == "contains" then
             if not v or not string.find(v, val, 1, true) then
@@ -51,12 +80,16 @@ end
 function _M.access(conf, ctx)
     for _, rule in ipairs(conf.rules or {}) do
         if match_rule(rule, ctx) then
-            if rule.inject_headers then
-                for k, v in pairs(rule.inject_headers) do
-                    core.request.set_header(k, v)
+            if rule.headers then
+                for _, h in ipairs(rule.headers) do
+                    if h.key and h.value then
+                        core.request.set_header(h.key, h.value)
+                    end
                 end
             end
-            ctx.var.upstream_id = rule.upstream_id
+            if rule.upstream_id then
+                ctx.var.upstream_id = rule.upstream_id
+            end
             core.log.info("multiple-upstream-plugin chose ", rule.upstream_id)
             return
         end

--- a/service/src/main/java/com/example/apisix/service/RouteService.java
+++ b/service/src/main/java/com/example/apisix/service/RouteService.java
@@ -207,20 +207,28 @@ public class RouteService {
                 upstreamIds.add(dynamicUid);
 
                 Map<String, Object> newRule = new LinkedHashMap<>();
-                if (item.containsKey("name")) {
-                    newRule.put("name", item.get("name"));
-                }
-                // expected: match_key -> value for http_model contains
+
                 if (item.containsKey("match")) {
-                    List<List<String>> match = new ArrayList<>();
-                    match.add(Arrays.asList("http_model", "contains", String.valueOf(item.get("match"))));
+                    Map<String, Object> match = new LinkedHashMap<>();
+                    List<Map<String, Object>> vars = new ArrayList<>();
+                    Map<String, Object> cond = new LinkedHashMap<>();
+                    cond.put("var_name", "http_x_model");
+                    cond.put("operator", "==");
+                    cond.put("value", String.valueOf(item.get("match")));
+                    vars.add(cond);
+                    match.put("vars", vars);
                     newRule.put("match", match);
                 }
+
                 newRule.put("upstream_id", dynamicUid);
+
                 if (item.containsKey("api_key")) {
-                    Map<String, Object> headers = new HashMap<>();
-                    headers.put("x-api-key", item.get("api_key"));
-                    newRule.put("inject_headers", headers);
+                    List<Map<String, Object>> headers = new ArrayList<>();
+                    Map<String, Object> header = new LinkedHashMap<>();
+                    header.put("key", "api-key");
+                    header.put("value", String.valueOf(item.get("api_key")));
+                    headers.add(header);
+                    newRule.put("headers", headers);
                 }
 
                 rules.add(newRule);


### PR DESCRIPTION
## Summary
- update `multiple-upstream-plugin` to use new rule structure
- adapt `RouteService` to write the updated format
- refresh docs about the new header names

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684534ec3d14832da233bc05806f034c